### PR TITLE
Bug : 그룹 리스트 반환 버그 해결

### DIFF
--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -2,11 +2,11 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate, Link } from 'react-router-dom';
 import { authActions } from '../../store/authSlice';
+import { alertActions } from '../../store/alertSlice';
 import axios from 'axios';
 import PasswordReset from './PasswordReset';
 import GitHubLogo from '../../assets/logo/github.svg';
 import GoogleLogo from '../../assets/logo/google.svg';
-
 import imgLogo from '../../assets/logo/imgLogo.png';
 
 const baseUrl = 'https://i11e206.p.ssafy.io';
@@ -14,7 +14,6 @@ const baseUrl = 'https://i11e206.p.ssafy.io';
 const Login = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-
   const [values, setValues] = useState({
     email: '',
     password: '',
@@ -42,19 +41,20 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(`${baseUrl}/api/auth`, {
+      await axios.post(`${baseUrl}/api/auth`, {
         email: values.email,
         password: values.password,
       });
-      console.log('로그인 성공', response);
-
       await getUserInfo();
-
       dispatch(authActions.login());
       navigate('/home');
     } catch (error) {
-      console.error('일반 로그인 실패', error);
-      alert('아이디 또는 비밀번호가 일치하지 않습니다.');
+      dispatch(
+        alertActions.showAlert({
+          message: error.response.data.message,
+          type: 'ERROR',
+        })
+      );
     }
   };
 
@@ -62,9 +62,13 @@ const Login = () => {
   const socialLogin = async (provider) => {
     try {
       window.location.href = `${baseUrl}/api/oauth2/authorization/${provider}`;
-      console.log('소셜 로그인 화면 이동 성공');
     } catch (error) {
-      console.log('소셜 로그인 화면 이동 실패', error);
+      dispatch(
+        alertActions.showAlert({
+          message: '소셜 로그인 실패',
+          type: 'ERROR',
+        })
+      );
     }
   };
 
@@ -73,11 +77,15 @@ const Login = () => {
       const response = await axios.get(`${baseUrl}/api/users/info`, {
         withCredentials: true,
       });
-
       dispatch(authActions.setUserInfo(response.data));
-      console.log('유저 정보 요청 성공', response);
     } catch (error) {
-      console.error('유저 정보 요청 실패', error);
+      dispatch(
+        alertActions.showAlert({
+          message:
+            '사용자 정보를 불러오는 데 실패하였습니다. 다시 시도해주세요.',
+          type: 'ERROR',
+        })
+      );
     }
   };
 

--- a/src/components/group/Group.jsx
+++ b/src/components/group/Group.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import Modal from '../common/Modal';
 import ButtonGroup from './ButtonGroup';
 import GroupList from './GroupList';
@@ -6,29 +7,35 @@ import CreateGroup from './CreateGroup';
 import JoinGroup from './JoinGroup';
 import GroupApi from '../../apis/GroupApi';
 import GroupDetail from './GroupDetail';
+import { alertActions } from '../../store/alertSlice';
 
 const Group = ({ isOpen, handleCloseGroup }) => {
+  const dispatch = useDispatch();
   const [activeModal, setActiveModal] = useState('list');
   const [groupData, setGroupData] = useState(null);
-  const [error, setError] = useState(null);
   const [woomsId, setWoomsId] = useState();
   const [page, setPage] = useState(0);
   const [totalPage, setTotalPage] = useState(0);
+
   useEffect(() => {
     const getGroupList = async () => {
       try {
         const data = await GroupApi.getMyGroup(page);
         setGroupData(data);
         setTotalPage(data.totalPages - 1);
-        setError(null);
-      } catch (err) {
-        console.error('Failed to fetch group data:', err);
-        setError('Failed to fetch group data. Please try again later.');
+      } catch (error) {
+        dispatch(
+          alertActions.showAlert({
+            message:
+              'Wooms 목록 조회에 실패하였습니다. 페이지를 새로고침 해주세요',
+            type: 'ERROR',
+          })
+        );
       }
     };
 
     getGroupList();
-  }, [page]);
+  });
 
   const handlePrevPage = () => {
     setPage((prev) => Math.max(0, prev - 1));


### PR DESCRIPTION
## 🙆‍♂️ Issue
#209 

## 📝 Description
그룹 리스트 반환 버그 해결
### 문제
- 첫 로그인 했을 경우 빈 그룹 리스트 반환
- 로그아웃 후 다른 계정 로그인 시 이전 사용자 그룹 리스트 반환

## ✨ Feature
어떤 기능인지 나열해주세요.
1. 그룹 리스트 반환 버그 해결

## 👌 Review
This closes #209 
상의할게 있어요! 아래 **두 방법 중 어떤 방법을 선택**할지 고민이 됩니다.
배포 사이트에서 테스트 해봤는데 그룹 목록 반환 이슈는 둘 다 해결되었습니다.

---

1. 현재 해결 방법으로, Group.jsx 의 아래와 같이 useEffect 의 의존성 배열(page) 제거를 하여 페이지가 렌더링 될 때마다 항상 useEffect 코드가 실행되게 바꾸어뒀습니다.
(해당 방법 적용 시 사용자 정보 이슈 해결 X, **추후 해결해야 할지도**)

※ 사용자 정보 불러오기 관련해서 이슈가 있었던 것 같은데 배포 페이지에서 어떤 경우에 발생하는지 찾지 못했습니다.

```javascript
  useEffect(() => {
    const getGroupList = async () => {
      try {
        const data = await GroupApi.getMyGroup(page);
        setGroupData(data);
        setTotalPage(data.totalPages - 1);
      } catch (error) {
        ... 생략 ...
      }
    };

    getGroupList();
  }, [page]); // 이 부분에서 의존성 배열 제거 
```
---

2. 기존 로그인의 경우 router 의 `useNavigate()`를 호출하여 페이지 전환, useEffect의 page 값만을 의존하여 데이터 변경 시도 
    -> 갱신된 그룹 데이터 불러오기 실패

**해결방법**: 로그인 시 `window.location.replace('/home')` 적용하여 로그인 후 '/home' 페이지가 모든 정보를 서버에 다시 요청
    -> 새로고침 효과, 이 방법이 새로고침을 했을 때의 효과를 나타내 가장 확실(방법 1로는 해결 안되는 사용자 정보 해결)하지만 해당 페이지에서 특정 컴포넌트의 데이터만을 변경한다는 csr의 장점을 상쇄

2번 방법  [useNavigate(), window.location.replace 차이 참고 사이트](https://80000coding.oopy.io/b2ba558a-187d-4945-a135-230e8a775931)