### PR TITLE
Refactor : 캐릭터 움직임 이미지 로딩 최적화

### DIFF
--- a/src/utils/loadCharacterImages.js
+++ b/src/utils/loadCharacterImages.js
@@ -1,57 +1,30 @@
-const directionMap = {
-  d: 0, // DOWN
-  u: 1, // UP
-  r: 2, // RIGHT
-  l: 3, // LEFT
-};
+const context = import.meta.glob('../assets/{0..11}/*.png', { eager: true });
 
-const loadCharacterImages = () => {
-  const allImages = {};
+// 2) 방향·프레임 맵
+const directionMap = { d:0, u:1, r:2, l:3 };
+const frameMap = new Map([1,2,4,5,6,8].map((frame, idx) => [frame, idx]));
 
-  // Vite의 import.meta.glob을 사용하여 동적으로 파일을 로드합니다.
-  const context = import.meta.glob('../assets/{0..11}/*.png', { eager: true });
+// 3) 최종 매핑 객체
+export const allCharacterImages = {};
 
-  // 프레임 번호를 순서대로 배열의 인덱스로 변환하기 위한 맵을 생성합니다.
-  const frameMap = new Map(
-    [1, 2, 4, 5, 6, 8].map((frame, index) => [frame, index])
-  );
+// 4) glob 결과를 순회하며 URL 문자열만 저장
+Object.entries(context).forEach(([filePath, mod]) => {
+  // '../assets/5/u4.png'  →  ['5', 'u4']
+  const [charNo, fileName] = filePath
+    .replace('../assets/', '')
+    .replace('.png','')
+    .split('/');
 
-  Object.keys(context).forEach((key) => {
-    // 파일 경로에서 상대 경로와 확장자를 제거하여 필요한 부분만 추출합니다.
-    const path = key.replace('../assets/', '').replace('.png', '');
+  const dirChar  = fileName[0];           // 'u'
+  const frameNum = parseInt(fileName[1],10); // 4
 
-    // 경로를 '/'로 분리하여 캐릭터 번호와 나머지 정보를 추출합니다.
-    const [characterNumber, ...rest] = path.split('/');
-    const [direction, frame] = rest[0].split('');
+  const dIdx = directionMap[dirChar];
+  const fIdx = frameMap.get(frameNum);
+  if (dIdx == null || fIdx == null) return;
 
-    // 캐릭터 번호가 존재하지 않는 경우 새로 초기화합니다.
-    if (!allImages[characterNumber]) {
-      allImages[characterNumber] = {};
-    }
+  allCharacterImages[charNo] ??= {};
+  allCharacterImages[charNo][dIdx] ??= [];
 
-    // 방향을 숫자로 변환합니다.
-    const directionIndex = directionMap[direction];
-    if (directionIndex === undefined) {
-      return;
-    }
-
-    // 방향에 대한 배열이 존재하지 않는 경우 새로 초기화합니다.
-    if (!allImages[characterNumber][directionIndex]) {
-      allImages[characterNumber][directionIndex] = [];
-    }
-
-    // 프레임 번호를 정수로 변환합니다.
-    const frameNumber = parseInt(frame, 10);
-    const index = frameMap.get(frameNumber);
-
-    if (index !== undefined) {
-      const img = new Image(); // Image 객체를 생성합니다.
-      img.src = context[key].default; // Image 객체에 이미지 경로를 설정합니다.
-      allImages[characterNumber][directionIndex][index] = img; // Image 객체를 저장합니다.
-    }
-  });
-
-  return allImages;
-};
-
-export default loadCharacterImages;
+  // mod.default 에는 “/src/assets/5/u4.png” 같은 URL 문자열
+  allCharacterImages[charNo][dIdx][fIdx] = mod.default;
+});

--- a/src/utils/useCharacterTextures.js
+++ b/src/utils/useCharacterTextures.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+import { Texture } from 'pixi.js';
+import { allCharacterImages } from '../utils/loadCharacterImages';
+
+export function useCharacterTextures(costume) {
+  const [textures, setTextures] = useState([[], [], [], []]);
+
+  useEffect(() => {
+    // 방향별 URL 객체: {0: [...], 1: [...], 2: [...], 3: [...]}
+    const dirs = allCharacterImages[String(costume)] || {};
+
+    // 0→DOWN,1→UP,2→RIGHT,3→LEFT 순서로 2중 배열 생성
+    const newTextures = [0,1,2,3].map((dir) => {
+      const urls = dirs[dir] || [];
+      return urls.map((url) => Texture.from(url));
+    });
+
+    setTextures(newTextures);
+  }, [costume]);
+
+  return textures;
+}

--- a/src/world/CharacterInHome.jsx
+++ b/src/world/CharacterInHome.jsx
@@ -1,13 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Sprite, Container } from '@pixi/react';
-import { Texture } from 'pixi.js';
 import collisions from '../assets/home/home-collisions';
 import {
   initializeCollisionMap,
   initializeBoundaries,
 } from '../utils/boundaryUtils';
 import Nickname from './Nickname';
-import loadCharacterImages from '../utils/loadCharacterImages';
+import { useCharacterTextures } from '../utils/useCharacterTextures';
 import InteractionSpeechBubble from './InteractionSpeechBubble';
 
 const Direction = {
@@ -51,11 +50,11 @@ const Character = ({
   const [isAnimating, setIsAnimating] = useState(false);
   const [isInteractionBed, setIsInteractionBed] = useState(false);
   const [isInteractionToilet, setIsInteractionToilet] = useState(false);
-  const [directionImages, setDirectionImages] = useState({});
 
   const animationFrameRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
-
+  const textures = useCharacterTextures(costume);
+  
   // 경계 맵 생성
   useEffect(() => {
     const collisionMap = initializeCollisionMap(collisions, 61);
@@ -63,12 +62,6 @@ const Character = ({
       initializeBoundaries(collisionMap, BoundaryWidth, BoundaryHeight, 15)
     );
   }, []);
-
-  useEffect(() => {
-    const allImages = loadCharacterImages();
-    const images = allImages[costume];
-    setDirectionImages(images);
-  }, [costume]);
 
   // 충돌 or 상호작용 여부 판정 함수
   const boundaryCollision = useCallback((boundary, x, y) => {
@@ -233,11 +226,9 @@ const Character = ({
 
   return (
     <Container x={charX} y={charY}>
-      {directionImages[direction] && directionImages[direction][stepIndex] && (
+      {textures[direction]?.[stepIndex] && (
         <Sprite
-          texture={Texture.from(directionImages[direction][stepIndex])}
-          x={0}
-          y={0}
+          texture={textures[direction][stepIndex]}
           width={CHAR_WIDTH}
           height={CHAR_HEIGHT}
         />

--- a/src/world/CharacterInMap.jsx
+++ b/src/world/CharacterInMap.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Texture } from 'pixi.js';
-import loadCharacterImages from '../utils/loadCharacterImages';
+import { useCharacterTextures } from '../utils/useCharacterTextures';
 import collisions from '../assets/map/map_collisions';
 import OtherCharacter from './Characters';
 import Nickname from './Nickname';
@@ -17,6 +16,8 @@ const Direction = {
   RIGHT: 2,
   LEFT: 3,
 };
+
+
 
 const MAP_WIDTH = 2048;
 const MAP_HEIGHT = 1536;
@@ -54,19 +55,20 @@ const Character = ({
 }) => {
   const [stepIndex, setStepIndex] = useState(0);
   const [direction, setDirection] = useState(Direction.DOWN);
-  const [directionImages, setDirectionImages] = useState({});
   const [charX, setCharX] = useState(width / 2);
   const [charY, setCharY] = useState(height / 2);
   const [isAnimating, setIsAnimating] = useState(false);
   const [collision, setCollision] = useState([]);
   const [characters, setCharacters] = useState([]); // 캐릭터 목록 상태
 
+
+  const textures = useCharacterTextures(costume);
   const animationFrameRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
 
   const BoundaryWidth = 32;
   const BoundaryHeight = 32;
-
+  
   // #stomp
   const [myChat, setMyChat] = useState('');
   useEffect(() => {
@@ -144,12 +146,6 @@ const Character = ({
       });
     }
   };
-
-  useEffect(() => {
-    const allImages = loadCharacterImages();
-    const images = allImages[costume];
-    setDirectionImages(images);
-  }, [costume]);
 
   useEffect(() => {
     const collisionMap = initializeCollisionMap(collisions, 64);
@@ -375,20 +371,18 @@ const Character = ({
     }
     animationFrameRef.current = requestAnimationFrame(animate);
   };
+  
 
   return (
     <>
       <Container x={charX} y={charY}>
-        {directionImages[direction] &&
-          directionImages[direction][stepIndex] && (
-            <Sprite
-              texture={Texture.from(directionImages[direction][stepIndex])}
-              x={0}
-              y={0}
-              width={CHAR_WIDTH}
-              height={CHAR_HEIGHT}
-            />
-          )}
+        {textures[direction]?.[stepIndex] && (
+          <Sprite
+            texture={textures[direction][stepIndex]}
+            width={CHAR_WIDTH}
+            height={CHAR_HEIGHT}
+          />
+        )}
         {myChat && (
           <SpeechBubble width={CHAR_WIDTH} height={CHAR_HEIGHT} text={myChat} />
         )}

--- a/src/world/Characters.jsx
+++ b/src/world/Characters.jsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Sprite, Container, Texture } from '@pixi/react';
+import { Sprite, Container } from '@pixi/react';
 import Nickname from './Nickname';
-import loadCharacterImages from '../utils/loadCharacterImages';
+import { useCharacterTextures } from '../utils/useCharacterTextures';
 import SpeechBubble from './SpeechBubble';
 
 const CHAR_WIDTH = 40; // 캐릭터 사이즈
@@ -18,21 +17,13 @@ const OtherCharacter = ({
   backgroundX,
   backgroundY,
 }) => {
-  const [directionImages, setDirectionImages] = useState({});
-
-  useEffect(() => {
-    const allImages = loadCharacterImages();
-    const images = allImages[costume];
-    setDirectionImages(images);
-  }, [costume]);
-
+  const textures = useCharacterTextures(costume);
+  
   return (
     <Container x={Number(x) + backgroundX} y={Number(y) + backgroundY}>
-      {directionImages[direction] && directionImages[direction][stepIndex] && (
+      {textures[direction]?.[stepIndex] && (
         <Sprite
-          image={directionImages[direction][stepIndex]}
-          x={0}
-          y={0}
+          texture={textures[direction][stepIndex]}
           width={CHAR_WIDTH}
           height={CHAR_HEIGHT}
         />


### PR DESCRIPTION
## 🙆‍♂️ Issue

#245

## 📝 Description

이미지 로딩 방식을 모듈·훅 레벨로 일원화하여 중복 로드 및 불필요한 `Texture.from()` 호출을 제거하고, 캐릭터 컴포넌트에서의 네트워크 요청을 초기 1회로 한정하는 성능 최적화를 적용했습니다.

## ✨ Feature

1. **`utils/loadCharacterImages.js`**
   * `import.meta.glob` + `allCharacterImages` 객체로 모듈 스코프에서 한 번만 이미지 URL 매핑
   
2. **`utils/useCharacterTextures.js`**
   * `useCharacterTextures` 훅 도입: `allCharacterImages` 기반으로 방향×프레임별 `Texture.from()`을 `useState`로 한 번만 래핑
   
3. **`Character` / `OtherCharacter` 컴포넌트**
   * 기존 `directionImages` state·`useEffect` 제거
   * `useCharacterTextures(costume)` 호출로 텍스처 관리 일원화
   * 불필요한 import 정리 및 `Texture.from` 중복 호출 제거
   

4. **네트워크 요청 최적화**
   * 개발 서버(ESM 모듈) 및 프로덕션 빌드에서 이미지 리소스가 초기 1회만 로드되고 이후 캐시 재사용

## 👌 Review

This closes #245

* Hook 호출 위치
* 네트워크 탭에서 PNG 요청이 초기 1회만 발생하는지 확인 부탁드립니다.
