### PR TITLE
Feat : api 버튼 로딩 적용

### DIFF
--- a/src/components/groupSpace/comment/CommentModal.jsx
+++ b/src/components/groupSpace/comment/CommentModal.jsx
@@ -4,6 +4,7 @@ import ButtonDetail from '../../group/ButtonDetail';
 import { GroupCommentApi } from '../../../apis/GroupSpaceApi';
 import { useDispatch } from 'react-redux';
 import { alertActions } from '../../../store/alertSlice';
+// throttle import 제거
 
 const Comment = ({ onClose }) => {
   const dispatch = useDispatch();
@@ -13,6 +14,7 @@ const Comment = ({ onClose }) => {
   const [comments, setComments] = useState([]);
   const [inputValue, setInputValue] = useState('');
   const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false); // loading 상태 추가
 
   // 댓글을 가져오는 함수
   const getComments = async () => {
@@ -33,8 +35,10 @@ const Comment = ({ onClose }) => {
   }, [woomsId, page]);
 
   // 댓글 작성 함수
-  const handleSubmit = async (event) => {
+  const doSubmit = async (event) => {
     event.preventDefault();
+    if (!inputValue.trim() || loading) return; // 중복 방지
+    setLoading(true);
     try {
       const response = await GroupCommentApi.postComment(woomsId, inputValue);
       setInputValue('');
@@ -52,6 +56,8 @@ const Comment = ({ onClose }) => {
           type: 'ERROR',
         })
       );
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -66,7 +72,7 @@ const Comment = ({ onClose }) => {
         </h2>
         <div className='pr-8'>
           <form
-            onSubmit={handleSubmit}
+            onSubmit={doSubmit}
             className='absolute left-1/2 pl-10 ml-4 transform -translate-x-1/2 top-20 flex items-center justify-center'
             style={{ width: '600px', height: '60px' }}
           >
@@ -82,8 +88,13 @@ const Comment = ({ onClose }) => {
                   border: 'none',
                   background: 'transparent',
                 }}
+                disabled={loading}
               />
-              <ButtonDetail buttonText='작성' onClick={handleSubmit} />
+              <ButtonDetail
+                buttonText={loading ? '작성 중...' : '작성'}
+                onClick={doSubmit}
+                disabled={loading || !inputValue.trim()}
+              />
             </div>
           </form>
           <div className='mt-32'>

--- a/src/components/groupSpace/letter/WriteLetter.jsx
+++ b/src/components/groupSpace/letter/WriteLetter.jsx
@@ -62,7 +62,7 @@ const WriteLetter = ({
             onChange={handleContentChange}
             className='absolute top-14 w-11/12 h-2/3 p-4 rounded resize-none bg-transparent overflow-hidden focus:outline-none leading-relaxed font-semibold'
             placeholder='편지 내용을 입력하세요!'
-            maxLength={350}
+            maxLength={500}
           />
           <div className='absolute bottom-36 right-2 p-4 flex flex-col items-end'>
             <p className='text-lg font-bold'>

--- a/src/components/groupSpace/letter/WriteLetterMain.jsx
+++ b/src/components/groupSpace/letter/WriteLetterMain.jsx
@@ -19,6 +19,7 @@ const WriteLetterMain = ({ isOpen, onClose }) => {
   const [isUserModalOpen, setUserModalOpen] = useState(true);
   const [isLetterModalOpen, setLetterModalOpen] = useState(false);
   const [isDateModalOpen, setDateModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false); // loading 상태 추가
 
   useEffect(() => {
     setSendDateTime(new Date().toISOString());
@@ -48,6 +49,8 @@ const WriteLetterMain = ({ isOpen, onClose }) => {
   };
 
   const sendLetter = async () => {
+    if (loading) return;
+    setLoading(true);
     try {
       const response = await baseUrl.post(
         '/letters',
@@ -75,6 +78,8 @@ const WriteLetterMain = ({ isOpen, onClose }) => {
           type: 'ERROR',
         })
       );
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -108,6 +113,7 @@ const WriteLetterMain = ({ isOpen, onClose }) => {
                 sendDateTime={sendDateTime}
                 onChange={handleSelectedDate}
                 onSubmit={sendLetter}
+                loading={loading}
               />
             )}
           </>

--- a/src/components/groupSpace/photo/UploadModal.jsx
+++ b/src/components/groupSpace/photo/UploadModal.jsx
@@ -108,7 +108,6 @@ const UploadModal = ({ onClose }) => {
   };
 
   const handleUpload = async () => {
-    console.log("업로드 실행!");
     if (files.length === 0) {
       dispatch(
         alertActions.showAlert({ message: '업로드할 사진이 없습니다.', type: 'ERROR' })
@@ -121,17 +120,16 @@ const UploadModal = ({ onClose }) => {
     try {
       const canvas = await html2canvas(polaroidRef.current);
       const dataURL = canvas.toDataURL('image/png');
-      console.log("dataURL : " + dataURL);
+
       
       const blob = await fetch(dataURL).then((res) => res.blob());
       console.log("blob : " + blob);
       const file = new File([blob], 'captured_image.png', {
         type: 'image/png',
       });
-      console.log("file : " + file);
+
       console.log(mapId);
       await GroupPhotoApi.postPhoto(woomsId, mapId, file);
-      console.log("돌아왔나?");
       dispatch(
         alertActions.showAlert({
           message: '사진이 성공적으로 업로드되었습니다.',


### PR DESCRIPTION
## 🙆‍♂️ Issue
#247 

## 📝 Description
이 PR은 아래 세 가지 주요 기능에 대해 API 호출 시 로딩 상태(버튼 비활성화)를 추가하여  
사용자 경험을 개선합니다.  
- 연타 방지 및 중복 요청 차단  
- 요청 진행 중임을 명확히 보여주는 UI 제공  

## ✨ Feature
1. **방명록 등록**  
   - 댓글 등록 버튼 클릭 시 작성중 표시  
   - API 요청 진행 중 버튼 `disabled` 처리  
2. **편지 보내기**  
   - 편지 전송 버튼에 로딩 상태 추가  
   - 요청 완료 또는 실패 시 버튼 활성화  
3. **사진 업로드**  
   - 파일 업로드 버튼/폼에 로딩 인디케이터 적용  
   - 업로드 중 진행 상태 표시 및 재시도 방지  

## 👌 Review
This closes #247  

