### PR TITLE
refactor: axios 직접 호출 → basicAxios 인스턴스로 통일

### DIFF
--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -4,14 +4,15 @@ import { useNavigate, Link } from 'react-router-dom';
 import { authActions } from '../../store/authSlice';
 import { alertActions } from '../../store/alertSlice';
 import { settingActions } from '../../store/settingSlice';
-import axios from 'axios';
+import basicAxios from '../../libs/axios/basicAxios'
 import PasswordReset from './PasswordReset';
 import GitHubLogo from '../../assets/logo/github.svg';
 import GoogleLogo from '../../assets/logo/google.svg';
 import LoadingBus from '../common/LoadingBus';
 import imgLogo from '../../assets/logo/imgLogo.png';
 
-const baseUrl = 'https://wooms.duckdns.org';
+// const baseUrl = 'https://wooms.duckdns.org';
+const baseUrl = 'http://localhost:8080';
 
 const Login = () => {
   const dispatch = useDispatch();
@@ -46,10 +47,11 @@ const Login = () => {
     e.preventDefault();
     dispatch(settingActions.startMove());
     try {
-      await axios.post(`${baseUrl}/api/auth`, {
+      await basicAxios.post(`/auth`, {
         email: values.email,
         password: values.password,
-      });
+      },
+    );
 
       await getUserInfo();
       dispatch(authActions.login());
@@ -83,9 +85,7 @@ const Login = () => {
 
   const getUserInfo = async () => {
     try {
-      const response = await axios.get(`${baseUrl}/api/users/info`, {
-        withCredentials: true,
-      });
+      const response = await basicAxios.get(`/users/info`);
 
       dispatch(authActions.setUserInfo(response.data));
     } catch (error) {

--- a/src/components/auth/OauthHandler.jsx
+++ b/src/components/auth/OauthHandler.jsx
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import axios from 'axios';
+import basicAxios from '../../libs/axios/basicAxios'
 import { authActions } from '../../store/authSlice';
 import Loading from '../common/Loading';
 
-const baseUrl = 'https://wooms.duckdns.org';
 
 const OauthHandler = () => {
   const navigate = useNavigate();
@@ -14,9 +13,7 @@ const OauthHandler = () => {
   useEffect(() => {
     const getUserInfo = async () => {
       try {
-        const response = await axios.get(`${baseUrl}/api/users/info`, {
-          withCredentials: true,
-        });
+        const response = await basicAxios.get(`/users/info`);
 
         dispatch(authActions.setUserInfo(response.data));
         dispatch(authActions.login());

--- a/src/components/auth/PasswordReset.jsx
+++ b/src/components/auth/PasswordReset.jsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
-
-const baseUrl = 'http://wooms.duckdns.org';
+import basicAxios from '../../libs/axios/basicAxios'
 
 const PasswordReset = ({ onClose }) => {
   const [emailInput, setEmailInput] = useState('');
@@ -42,13 +40,9 @@ const PasswordReset = ({ onClose }) => {
   const getTempPassword = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(`${baseUrl}/api/auth/password`, {
-        email: emailInput,
-      });
-      console.log('임시 비밀번호 발급 성공', response);
+      const response = await basicAxios.post(`/auth/password`, {email: emailInput});
       setMessage('임시 비밀번호가 발급되었습니다. 이메일을 확인해주세요.');
     } catch (error) {
-      console.error('임시 비밀번호 발급 실패', error);
       setIsValidEmail(false);
       setMessage('이메일 전송하는데 실패했습니다. 잠시 후 다시 시도해주세요.');
     }

--- a/src/components/auth/Signup.jsx
+++ b/src/components/auth/Signup.jsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import axios from 'axios';
+import basicAxios from '../../libs/axios/basicAxios'
 
 import imgLogo from '../../assets/logo/imgLogo.png';
 
-const baseUrl = 'https://wooms.duckdns.org';
 
 const Signup = () => {
   const navigate = useNavigate();
@@ -61,7 +60,7 @@ const Signup = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(`${baseUrl}/api/auth/users`, {
+      const response = await basicAxios.post(`/auth/users`, {
         name: values.name,
         email: values.email,
         password: values.password,
@@ -78,14 +77,13 @@ const Signup = () => {
   const checkEmail = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(`${baseUrl}/api/auth/email`, {
+      setCodeAbled(true);
+      await basicAxios.post(`/auth/email`, {
         email: values.email,
       });
-      // 인증 코드 요청 버튼 활성화
-      setCodeAbled(true);
 
       setEmailMessage('인증 코드가 발송되었습니다.');
-      console.log(response.data);
+
     } catch (error) {
       setCodeAbled(false);
       // 10초 후 인증 코드 요청 버튼 활성화
@@ -104,7 +102,7 @@ const Signup = () => {
   const checkEmailCode = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(`${baseUrl}/api/auth/email/code`, {
+      const response = await basicAxios.post(`/auth/email/code`, {
         email: values.email,
         code: values.code,
       });


### PR DESCRIPTION
## 🙆‍♂️ Issue

This closes #250 


## 📝 Description

프론트엔드 전반에서 중복되고 하드코딩된 `axios` 요청을 제거하고, 공통 설정을 갖는 `basicAxios` 인스턴스로 통일했습니다.
`baseURL`, `withCredentials` 등의 설정을 매번 반복하지 않도록 하여 코드의 일관성과 유지보수성을 높였습니다.



## ✨ Feature

다음 컴포넌트에서 `axios` 직접 호출을 제거하고 `basicAxios`로 리팩토링했습니다:

1. `Login.jsx`

   * 로그인 요청 (`/auth`)
   * 사용자 정보 조회 (`/users/info`)
2. `Signup.jsx`

   * 회원가입 요청 (`/auth/users`)
   * 이메일 인증 요청 (`/auth/email`)
   * 인증 코드 검증 (`/auth/email/code`)
3. `PasswordReset.jsx`

   * 임시 비밀번호 발급 (`/auth/password`)
4. `OauthHandler.jsx`

   * 소셜 로그인 후 사용자 정보 조회 (`/users/info`)


## 👌 Review

This closes #250 
