### PR TITLE
Feat : 소켓 연결 및 유실 정책 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Frontend CI/CD (scp → SSH)
 
 on:
   push:
-    branches: [ 'feat#249' ]
+    branches: [ 'develop#2' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Frontend CI/CD (scp → SSH)
 
 on:
   push:
-    branches: [ 'develop#2' ]
+    branches: [ 'feat#249' ]
   workflow_dispatch:
 
 jobs:

--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -4,7 +4,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { authActions } from '../../store/authSlice';
 import { alertActions } from '../../store/alertSlice';
 import { settingActions } from '../../store/settingSlice';
-import axios from 'axios';
+import basicAxios from '../../libs/axios/basicAxios'
 import PasswordReset from './PasswordReset';
 import GitHubLogo from '../../assets/logo/github.svg';
 import GoogleLogo from '../../assets/logo/google.svg';
@@ -12,6 +12,7 @@ import LoadingBus from '../common/LoadingBus';
 import imgLogo from '../../assets/logo/imgLogo.png';
 
 const baseUrl = 'https://wooms.duckdns.org';
+// const baseUrl = 'http://localhost:8080';
 
 const Login = () => {
   const dispatch = useDispatch();
@@ -46,10 +47,11 @@ const Login = () => {
     e.preventDefault();
     dispatch(settingActions.startMove());
     try {
-      await axios.post(`${baseUrl}/api/auth`, {
+      await basicAxios.post(`/auth`, {
         email: values.email,
         password: values.password,
-      });
+      },
+    );
 
       await getUserInfo();
       dispatch(authActions.login());
@@ -83,9 +85,7 @@ const Login = () => {
 
   const getUserInfo = async () => {
     try {
-      const response = await axios.get(`${baseUrl}/api/users/info`, {
-        withCredentials: true,
-      });
+      const response = await basicAxios.get(`/users/info`);
 
       dispatch(authActions.setUserInfo(response.data));
     } catch (error) {

--- a/src/libs/socket/client.js
+++ b/src/libs/socket/client.js
@@ -3,9 +3,10 @@ const token = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3d';
 
 const client = new Client({
   brokerURL: 'wss://wooms.duckdns.org/ws',
+  // brokerURL: 'ws://localhost:8080/ws',
   reconnectDelay: 5000,
-  heartbeatIncoming: 4000,
-  heartbeatOutgoing: 4000,
+  heartbeatIncoming: 10000,
+  heartbeatOutgoing: 10000,
   onConnect: (frame) => {
     console.log('Connected: ' + frame);
   },

--- a/src/world/CharacterInMap.jsx
+++ b/src/world/CharacterInMap.jsx
@@ -1,57 +1,52 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { Sprite, Container } from '@pixi/react';
 import { useCharacterTextures } from '../utils/useCharacterTextures';
 import collisions from '../assets/map/map_collisions';
 import OtherCharacter from './Characters';
 import Nickname from './Nickname';
-import {
-  initializeCollisionMap,
-  initializeBoundaries,
-} from '../utils/boundaryUtils';
-import { flushSync } from 'react-dom';
-import { Sprite, Container } from '@pixi/react';
 import SpeechBubble from './SpeechBubble';
-const Direction = {
-  DOWN: 0,
-  UP: 1,
-  RIGHT: 2,
-  LEFT: 3,
-};
+import { initializeCollisionMap, initializeBoundaries } from '../utils/boundaryUtils';
+import { flushSync } from 'react-dom';
 
-
-
+const Direction = { DOWN: 0, UP: 1, RIGHT: 2, LEFT: 3 };
 const MAP_WIDTH = 2048;
 const MAP_HEIGHT = 1536;
-const CHAR_WIDTH = 40; // 캐릭터 사이즈
+const CHAR_WIDTH = 40;
 const CHAR_HEIGHT = 60;
-const MOVE_DISTANCE = 22; // 한 프레임별 움직일 거리
-const FRAME_INTERVAL = 60; // 프레임이 전환될 간격
+const MOVE_DISTANCE = 22;
+const FRAME_INTERVAL = 60;
 const STEP_COUNT = 6;
+const BoundaryWidth = 32;
+const BoundaryHeight = 32;
 
-// #todo: 추후 캐릭터 코스튬, 닉네임 사용자 정보에 맞게 수정
-const Character = ({
+const CharacterInMap = ({
   width,
   height,
   costume,
   nickname,
-  stompClient,
-  connected,
-  token,
-  messageObj,
-  setBackgroundX,
-  setBackgroundY,
+  // 카메라/위치
   backgroundX,
   backgroundY,
+  setBackgroundX,
+  setBackgroundY,
+  setCharacterX,
+  setCharacterY,
+  // 인터랙션 상태
   isOpenPhoto,
   isOpenPhotomap,
   isOpenGuestbook,
   isOpenRadioRead,
   isOpenRadioWrite,
-  setCharacterX,
-  setCharacterY,
   setIsInteractive,
   setRadioWriteInteractive,
   setRadioReadInteractive,
   isChatting,
+  // WS
+  connected,
+  sendMove,         // 부모가 내려주는 발행 콜백
+  others = [],      // 부모가 내려주는 타인 목록
+  // 채팅 말풍선(내 것만 여기서 처리)
+  messageObj,
 }) => {
   const [stepIndex, setStepIndex] = useState(0);
   const [direction, setDirection] = useState(Direction.DOWN);
@@ -59,113 +54,29 @@ const Character = ({
   const [charY, setCharY] = useState(height / 2);
   const [isAnimating, setIsAnimating] = useState(false);
   const [collision, setCollision] = useState([]);
-  const [characters, setCharacters] = useState([]); // 캐릭터 목록 상태
 
+  const [myChat, setMyChat] = useState('');
 
   const textures = useCharacterTextures(costume);
   const animationFrameRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
 
-  const BoundaryWidth = 32;
-  const BoundaryHeight = 32;
-  
-  // #stomp
-  const [myChat, setMyChat] = useState('');
+  // 내 채팅 말풍선만 여기서 반영
   useEffect(() => {
-    // messageObj가 정의되어 있고 nickname과 content가 있는지 확인
-    if (messageObj && messageObj.nickname && messageObj.content) {
-      if (messageObj.nickname === nickname) setMyChat(messageObj.content);
-      else
-        setCharacters((prevCharacters) =>
-          prevCharacters.map((char) =>
-            char.nickname === messageObj.nickname
-              ? { ...char, message: messageObj.content }
-              : char
-          )
-        );
+    if (messageObj && messageObj.nickname === nickname && messageObj.content) {
+      setMyChat(messageObj.content);
     }
-  }, [messageObj]);
-  const updateCharacterPosition = (newData) => {
-    setCharacters((prevCharacters) => {
-      if (nickname === newData.nickname) return prevCharacters;
-      if (!prevCharacters) return [newData];
-      const existingCharacterIndex = prevCharacters.findIndex(
-        (character) => character.nickname === newData.nickname
-      );
+  }, [messageObj, nickname]);
 
-      if (existingCharacterIndex !== -1) {
-        const updatedCharacters = [...prevCharacters];
-        updatedCharacters[existingCharacterIndex] = newData;
-        return updatedCharacters;
-      } else {
-        return [...prevCharacters, newData];
-      }
-    });
-  };
-
-  useEffect(() => {
-    if (!stompClient || !connected) return;
-
-    // 움직임 구독 설정
-    const moveSubscription = stompClient.subscribe(
-      '/ws/wooms/move/' + token,
-      (message) => {
-        try {
-          const parseMessage = JSON.parse(message.body);
-          // console.log(parseMessage);
-          // 움직임 처리
-          const { nickname, x, y, direction, stepId, costume } = parseMessage;
-
-          // 캐릭터 위치 업데이트
-          updateCharacterPosition({
-            nickname,
-            x,
-            y,
-            direction,
-            stepId,
-            costume,
-          });
-        } catch (err) {
-          console.log('Failed to parse move message:', err);
-        }
-      }
-    );
-
-    // 컴포넌트 언마운트 시 구독 해제
-    return () => {
-      moveSubscription.unsubscribe();
-    };
-  }, [stompClient, connected, token]);
-
-  const sendMove = (characterInfo) => {
-    // console.log('send', characterInfo, backgroundX, backgroundY);
-    if (stompClient && connected) {
-      stompClient.publish({
-        destination: '/ws/send/move/' + token,
-        body: JSON.stringify(characterInfo),
-      });
-    }
-  };
-
+  // 충돌 맵 초기화
   useEffect(() => {
     const collisionMap = initializeCollisionMap(collisions, 64);
-    const coll = initializeBoundaries(
-      collisionMap,
-      BoundaryWidth,
-      BoundaryHeight,
-      29870
-    );
-    const coll2 = initializeBoundaries(
-      collisionMap,
-      BoundaryWidth,
-      BoundaryHeight,
-      93988
-    );
-    coll.push(...coll2);
-    setCollision(coll);
+    const c1 = initializeBoundaries(collisionMap, BoundaryWidth, BoundaryHeight, 29870);
+    const c2 = initializeBoundaries(collisionMap, BoundaryWidth, BoundaryHeight, 93988);
+    setCollision([...c1, ...c2]);
   }, []);
 
-  // 충돌 여부 판정 함수
+  // 충돌 판정
   const boundaryCollision = useCallback(
     (collisions, cx, cy, bx, by) => {
       return collisions.some((col) => {
@@ -180,7 +91,7 @@ const Character = ({
     [collision]
   );
 
-  // 키 눌렀을 때 실행될 함수
+  // 키 입력 처리
   const handleArrowKeyDown = useCallback(
     (e) => {
       if (isChatting) return;
@@ -222,9 +133,6 @@ const Character = ({
       }
     },
     [
-      charX,
-      charY,
-      stepIndex,
       direction,
       isAnimating,
       isOpenPhoto,
@@ -233,16 +141,16 @@ const Character = ({
       isOpenRadioRead,
       isOpenRadioWrite,
       isChatting,
+      setIsInteractive,
+      setRadioReadInteractive,
+      setRadioWriteInteractive,
     ]
   );
 
-  // 키를 누르다 뗐을 때 실행할 함수
   const handleArrowKeyUp = useCallback(() => {
     setIsAnimating(false);
     setStepIndex(0);
-    if (animationFrameRef.current) {
-      cancelAnimationFrame(animationFrameRef.current);
-    }
+    if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
   }, []);
 
   useEffect(() => {
@@ -254,31 +162,9 @@ const Character = ({
     };
   }, [handleArrowKeyDown, handleArrowKeyUp]);
 
-  // 애니메이션을 시작하거나 중단하는 함수
-  useEffect(() => {
-    if (isAnimating) {
-      animationFrameRef.current = requestAnimationFrame(animate);
-    } else if (animationFrameRef.current) {
-      cancelAnimationFrame(animationFrameRef.current);
-    }
-
-    return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-      }
-    };
-  }, [isAnimating, stepIndex, direction]);
-
-  // // 실제로 캐릭터가 맵의 어느 위치에 있는지 계산해주는 함수
-  // const getCharPos = (charX, charY, mapX, mapY) => {
-  //   console.log(charX, charY, mapX, mapY);
-  //   return [charX - mapX, charY - mapY];
-  // };
-
+  // 애니메이션 루프
   const animate = (timestamp) => {
-    if (!lastFrameTimeRef.current) {
-      lastFrameTimeRef.current = timestamp;
-    }
+    if (!lastFrameTimeRef.current) lastFrameTimeRef.current = timestamp;
     const deltaTime = timestamp - lastFrameTimeRef.current;
 
     if (deltaTime > FRAME_INTERVAL) {
@@ -288,9 +174,10 @@ const Character = ({
       let newY = charY;
       let newBackgroundX = backgroundX;
       let newBackgroundY = backgroundY;
-      // Center인지 확인하는 함수
-      const isCenterX = () => charX == width / 2;
-      const isCenterY = () => charY == height / 2;
+
+      const isCenterX = () => charX === width / 2;
+      const isCenterY = () => charY === height / 2;
+
       switch (direction) {
         case Direction.UP:
           if (newBackgroundY + MOVE_DISTANCE <= 0 && isCenterY()) {
@@ -300,10 +187,7 @@ const Character = ({
           }
           break;
         case Direction.DOWN:
-          if (
-            newBackgroundY - MOVE_DISTANCE >= -MAP_HEIGHT + height &&
-            isCenterY()
-          ) {
+          if (newBackgroundY - MOVE_DISTANCE >= -MAP_HEIGHT + height && isCenterY()) {
             newBackgroundY -= MOVE_DISTANCE;
           } else {
             newY += MOVE_DISTANCE;
@@ -317,10 +201,7 @@ const Character = ({
           }
           break;
         case Direction.RIGHT:
-          if (
-            newBackgroundX - MOVE_DISTANCE >= -MAP_WIDTH + width &&
-            isCenterX()
-          ) {
+          if (newBackgroundX - MOVE_DISTANCE >= -MAP_WIDTH + width && isCenterX()) {
             newBackgroundX -= MOVE_DISTANCE;
           } else {
             newX += MOVE_DISTANCE;
@@ -329,23 +210,14 @@ const Character = ({
         default:
           break;
       }
-      // 경계에 왔을 경우 카메라 고정
-      if (newBackgroundX > 0) newBackgroundX = 0;
-      if (newBackgroundX < -MAP_WIDTH + width)
-        newBackgroundX = -MAP_WIDTH + width;
-      if (newBackgroundY > 0) newBackgroundY = 0;
-      if (newBackgroundY < -MAP_HEIGHT + height)
-        newBackgroundY = -MAP_HEIGHT + height;
 
-      if (
-        !boundaryCollision(
-          collision,
-          newX,
-          newY,
-          newBackgroundX,
-          newBackgroundY
-        )
-      ) {
+      // 카메라 경계
+      if (newBackgroundX > 0) newBackgroundX = 0;
+      if (newBackgroundX < -MAP_WIDTH + width) newBackgroundX = -MAP_WIDTH + width;
+      if (newBackgroundY > 0) newBackgroundY = 0;
+      if (newBackgroundY < -MAP_HEIGHT + height) newBackgroundY = -MAP_HEIGHT + height;
+
+      if (!boundaryCollision(collision, newX, newY, newBackgroundX, newBackgroundY)) {
         flushSync(() => {
           setCharX(newX);
           setCharY(newY);
@@ -353,15 +225,18 @@ const Character = ({
           setCharacterY(newY);
           setBackgroundX(newBackgroundX);
           setBackgroundY(newBackgroundY);
-          // const pos = getCharPos(newX, newY, newBackgroundX, newBackgroundY);
-          sendMove({
-            x: newX - newBackgroundX,
-            y: newY - newBackgroundY,
-            direction: direction,
-            stepId: stepIndex,
-            nickname: nickname,
-            costume: costume,
-          });
+
+          if (connected && sendMove) {
+            // 서버는 월드 좌표 기준(x - mapX, y - mapY)
+            sendMove({
+              x: newX - newBackgroundX,
+              y: newY - newBackgroundY,
+              direction,
+              stepId: stepIndex,
+              nickname,
+              costume,
+            });
+          }
         });
       } else {
         setIsAnimating(false);
@@ -371,40 +246,53 @@ const Character = ({
     }
     animationFrameRef.current = requestAnimationFrame(animate);
   };
-  
+
+  useEffect(() => {
+    if (isAnimating) {
+      animationFrameRef.current = requestAnimationFrame(animate);
+    } else if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+    return () => {
+      if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
+    };
+  }, [isAnimating, stepIndex, direction, connected, backgroundX, backgroundY, charX, charY]);
+
+  // 다른 캐릭터들의 말풍선: messageObj를 여기서 합성해서 내려보냄
+  const derivedOthers = others.map((c) =>
+    messageObj?.nickname === c.nickname && messageObj?.content
+      ? { ...c, message: messageObj.content }
+      : c
+  );
 
   return (
     <>
+      {/* 나 */}
       <Container x={charX} y={charY}>
         {textures[direction]?.[stepIndex] && (
-          <Sprite
-            texture={textures[direction][stepIndex]}
-            width={CHAR_WIDTH}
-            height={CHAR_HEIGHT}
-          />
+          <Sprite texture={textures[direction][stepIndex]} width={CHAR_WIDTH} height={CHAR_HEIGHT} />
         )}
-        {myChat && (
-          <SpeechBubble width={CHAR_WIDTH} height={CHAR_HEIGHT} text={myChat} />
-        )}
+        {myChat && <SpeechBubble width={CHAR_WIDTH} height={CHAR_HEIGHT} text={myChat} />}
         <Nickname width={CHAR_WIDTH} height={CHAR_HEIGHT} text={nickname} />
       </Container>
-      {characters &&
-        characters.map((character) => (
-          <OtherCharacter
-            key={`${character.nickname}-${character.stepId}`}
-            x={character.x}
-            y={character.y}
-            direction={character.direction}
-            stepIndex={character.stepId}
-            costume={character.costume}
-            nickname={character.nickname}
-            character={character}
-            backgroundX={backgroundX}
-            backgroundY={backgroundY}
-          />
-        ))}
+
+      {/* 타인 */}
+      {derivedOthers.map((character) => (
+        <OtherCharacter
+          key={character.nickname} // 안정 키
+          x={character.x}
+          y={character.y}
+          direction={character.direction}
+          stepIndex={character.stepId}
+          costume={character.costume}
+          nickname={character.nickname}
+          character={character}
+          backgroundX={backgroundX}
+          backgroundY={backgroundY}
+        />
+      ))}
     </>
   );
 };
 
-export default Character;
+export default CharacterInMap;

--- a/src/world/CharacterInMap.jsx
+++ b/src/world/CharacterInMap.jsx
@@ -54,6 +54,7 @@ const CharacterInMap = ({
   const [charY, setCharY] = useState(height / 2);
   const [isAnimating, setIsAnimating] = useState(false);
   const [collision, setCollision] = useState([]);
+  const announcedRef = useRef(false);
 
   const [myChat, setMyChat] = useState('');
 
@@ -90,6 +91,29 @@ const CharacterInMap = ({
     },
     [collision]
   );
+
+  useEffect(() => {
+    if (connected && sendMove && !announcedRef.current) {
+      announcedRef.current = true;
+
+      const worldX = charX - backgroundX;
+      const worldY = charY - backgroundY;
+
+      sendMove({
+        x: worldX,
+        y: worldY,
+        direction,    
+        stepId: 1,    
+        nickname,
+        costume,
+      });
+    }
+  }, [connected, sendMove, charX, charY, backgroundX, backgroundY, direction, nickname, costume]);
+
+  // 끊기면 다음 연결 때 또 보낼 수 있도록 리셋
+  useEffect(() => {
+    if (!connected) announcedRef.current = false;
+  }, [connected]);
 
   // 키 입력 처리
   const handleArrowKeyDown = useCallback(

--- a/src/world/Map.jsx
+++ b/src/world/Map.jsx
@@ -1,6 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { groupActions } from '../store/groupSlice';
 import { Stage, Sprite, Container, AnimatedSprite } from '@pixi/react';
 import { OutlineFilter } from '@pixi/filter-outline';
 import basicAxios from '../libs/axios/basicAxios';
@@ -31,18 +30,31 @@ const Map = () => {
   const loading = useSelector((state) => state.setting.isMoving);
 
   useEffect(() => {
-    if (loading)
-      setTimeout(() => {
-        dispatch(settingActions.stopMove());
-      }, 1500);
-  }, [loading]);
+    if (loading) {
+      const t = setTimeout(() => dispatch(settingActions.stopMove()), 1500);
+      return () => clearTimeout(t);
+    }
+  }, [loading, dispatch]);
 
   const width = window.screen.width;
   const height = window.innerHeight;
   const pathname = window.location.pathname;
-  const woomsId = pathname.split('/')[2];
+
+  // 방 식별자: 그룹 정보에 있으면 그걸 우선, 없으면 URL에서 추출
   const groupInfo = useSelector((state) => state.group.groupInfo);
+  const roomId = useMemo(
+    () => groupInfo?.woomsInviteCode ?? pathname.split('/')[2],
+    [groupInfo?.woomsInviteCode, pathname]
+  );
+
   const userInfo = useSelector((state) => state.auth.userInfo);
+  const [nickname, setNickname] = useState(userInfo.nickname);
+  const [costume, setCostume] = useState(userInfo.costume);
+  useEffect(() => {
+    setNickname(userInfo.nickname);
+    setCostume(userInfo.costume);
+  }, [userInfo]);
+
   const [backgroundX, setBackgroundX] = useState(-300);
   const [backgroundY, setBackgroundY] = useState(-300);
 
@@ -66,61 +78,18 @@ const Map = () => {
   const [isChatting, setIsChatting] = useState(false);
   const [messageObj, setMessageObj] = useState({});
 
-  const photoX = 1417;
-  const photoY = 227;
-  const photoWidth = 266;
-  const photoHeight = 220;
-
-  const photomapX = 1260;
-  const photomapY = 515;
-  const photomapWidth = 98;
-  const photomapHeight = 90;
-
-  const guestbookX = 347;
-  const guestbookY = 620;
-  const guestbookWidth = 116;
-  const guestbookHeight = 116;
-
-  const radioX = 490;
-  const radioY = 450;
-  const radioWidth = 80;
-  const radioHeight = 63;
-
-  const fountainX = 1337;
-  const fountainY = 880;
-  const fountainWidth = 239;
-  const fountainHeight = 176;
+  // 정적 리소스 좌표
+  const photoX = 1417, photoY = 227, photoWidth = 266, photoHeight = 220;
+  const photomapX = 1260, photomapY = 515, photomapWidth = 98, photomapHeight = 90;
+  const guestbookX = 347, guestbookY = 620, guestbookWidth = 116, guestbookHeight = 116;
+  const radioX = 490, radioY = 450, radioWidth = 80, radioHeight = 63;
+  const fountainX = 1337, fountainY = 880, fountainWidth = 239, fountainHeight = 176;
   const getRandomDelay = () => Math.random() * 10000;
 
-  const fishs = [
-    {
-      x: 960,
-      y: 975,
-    },
-    {
-      x: 1600,
-      y: 1450,
-    },
-    {
-      x: 800,
-      y: 670,
-    },
-  ];
-  const waterLeafs = [
-    {
-      x: 900,
-      y: 833,
-    },
-    {
-      x: 770,
-      y: 670,
-    },
-    {
-      x: 750,
-      y: 1020,
-    },
-  ];
-  // 캐릭터의 위치 변경에 따른 정적인 요소의 위치 조정
+  const fishs = [{x:960,y:975},{x:1600,y:1450},{x:800,y:670}];
+  const waterLeafs = [{x:900,y:833},{x:770,y:670},{x:750,y:1020}];
+
+  // 좌표 변환 헬퍼
   const calculateStaticElementPosition = useCallback(() => {
     return {
       px: photoX + backgroundX,
@@ -134,42 +103,112 @@ const Map = () => {
       fx: fountainX + backgroundX,
       fy: fountainY + backgroundY,
     };
-  }, [characterX, characterY, backgroundX, backgroundY, width, height]);
+  }, [backgroundX, backgroundY]);
 
-  // #stomp
+  // --- WebSocket (STOMP) 상태 ---
   const [connected, setConnected] = useState(false);
-  const [nickname, setNickname] = useState(userInfo.nickname);
-  const [costume, setCostume] = useState(userInfo.costume);
-  useEffect(() => {
-    setNickname(userInfo.nickname);
-    setCostume(userInfo.costume);
-  }, [userInfo]);
+  // others: 타인만 별도 관리 (nickname을 key로 관리하면 중복 방지 쉬움)
+  const [othersDict, setOthersDict] = useState({});
 
-  useEffect(() => {
-    client.activate();
-    client.onConnect = () => {
-      console.log('STOMP client connected');
-      setConnected(true);
-      basicAxios({
-        method: 'post',
-        url: `/join/${groupInfo.woomsInviteCode}`,
-      })
-        .then((res) => console.log(res.data))
-        .catch((err) => console.log(err));
-    };
+  // upsert & remove
+  const upsertOther = useCallback((p) => {
+    if (!p?.nickname || p.nickname === nickname) return;
+    setOthersDict((prev) => ({ ...prev, [p.nickname]: p }));
+  }, [nickname]);
 
-    client.onDisconnect = () => {
-      console.log('STOMP client disconnected');
-      setConnected(false);
-    };
-
-    return () => {
-      client.deactivate();
-    };
+  const removeOther = useCallback((nick) => {
+    if (!nick) return;
+    setOthersDict((prev) => {
+      const c = { ...prev };
+      delete c[nick];
+      return c;
+    });
   }, []);
 
-  // #end-stomp
+  const others = useMemo(() => Object.values(othersDict), [othersDict]);
 
+  // STOMP 연결/구독 + 초기 스냅샷 처리
+  useEffect(() => {
+    if (!roomId) return;
+
+    client.onConnect = () => {
+      setConnected(true);
+
+      // 1) 초기 스냅샷: 개인 큐
+      const initSub = client.subscribe('/user/queue/init', (msg) => {
+        try {
+          const data = JSON.parse(msg.body);
+          console.log(data);
+          upsertOther(data);
+        } catch (e) {
+          console.error('init parse error', e);
+        }
+      });
+
+      // 2) MOVE 브로드캐스트
+      const moveSub = client.subscribe(`/ws/wooms/move/${roomId}`, (msg) => {
+        try {
+          const data = JSON.parse(msg.body);
+          upsertOther(data);
+        } catch (e) {
+          console.error('move parse error', e);
+        }
+      });
+
+      // 3) DISCONNECT 브로드캐스트
+      const discSub = client.subscribe(`/ws/wooms/disconnect/${roomId}`, (msg) => {
+        try {
+          const { nickname: who } = JSON.parse(msg.body);
+          removeOther(who);
+        } catch (e) {
+          console.error('disc parse error', e);
+        }
+      });
+
+      // // 4) Fallback: 개인 큐를 못 받는 이슈 대비해서 HTTP 초기화
+      // const timer = setTimeout(async () => {
+      //   try {
+      //     // 백엔드 @PostMapping("/api/join/{woomsId}") 맞춤
+      //     const res = await basicAxios.post(`/api/join/${roomId}`);
+      //     const list = res?.data?.characters || [];
+      //     list.forEach(upsertOther);
+      //   } catch (e) {
+      //     console.warn('HTTP init fallback failed', e);
+      //   }
+      // }, 600);
+
+      client.onDisconnect = () => setConnected(false);
+
+      return () => {
+        try {
+          initSub.unsubscribe();
+          moveSub.unsubscribe();
+          discSub.unsubscribe();
+        } catch (_) {}
+        clearTimeout(timer);
+      };
+    };
+
+    if (!client.active) client.activate();
+    return () => {
+      if (client.active) client.deactivate();
+    };
+  }, [roomId, upsertOther, removeOther]);
+
+  // 자식으로 내려줄 발행 콜백
+  const sendMove = useCallback((payload) => {
+    if (!connected) return;
+    try {
+      client.publish({
+        destination: `/ws/send/move/${roomId}`,
+        body: JSON.stringify(payload),
+      });
+    } catch (e) {
+      console.error('publish move failed', e);
+    }
+  }, [connected, roomId]);
+
+  // 인터랙션 열기/닫기
   useEffect(() => {
     if (isInteractive) {
       setIsOpenPhoto(false);
@@ -185,49 +224,25 @@ const Map = () => {
     } else if (radioWriteInteractive) {
       if (isNearRadio) setIsOpenRadioWrite(true);
     }
-  }, [isInteractive, radioReadInteractive, radioWriteInteractive]);
+  }, [isInteractive, radioReadInteractive, radioWriteInteractive, isNearPhoto, isNearPhotomap, isNearGuestbook, isNearRadio]);
 
-  const handleClosePhoto = () => {
-    setIsOpenPhoto(false);
-  };
-  const handleClosePhotomap = () => {
-    setIsOpenPhotomap(false);
-  };
-  const handleCloseGuestbook = () => {
-    console.log('click');
-    setIsOpenGuestbook(false);
-  };
-  const handleCloseRadioRead = () => {
-    console.log('click');
-    setIsOpenRadioRead(false);
-  };
-  const handleCloseRadioWrite = () => {
-    console.log('click');
-    setIsOpenRadioWrite(false);
-  };
-  const isNear = (
-    charX,
-    charY,
-    elementX,
-    elementY,
-    elementWidth,
-    elementHeight
-  ) => {
-    // 사각형 1의 경계
+  const handleClosePhoto = () => setIsOpenPhoto(false);
+  const handleClosePhotomap = () => setIsOpenPhotomap(false);
+  const handleCloseGuestbook = () => setIsOpenGuestbook(false);
+  const handleCloseRadioRead = () => setIsOpenRadioRead(false);
+  const handleCloseRadioWrite = () => setIsOpenRadioWrite(false);
+
+  const isNear = (charX, charY, elementX, elementY, elementWidth, elementHeight) => {
     const rect1Right = charX + 40;
     const rect1Bottom = charY + 60;
-
-    // 사각형 2의 경계
     const rect2Right = elementX + elementWidth + 30;
     const rect2Bottom = elementY + elementHeight + 30;
-
-    // 겹침 여부를 확인하는 조건
     return !(
-      rect1Right < elementX || // 사각형 1의 오른쪽이 사각형 2의 왼쪽보다 왼쪽에 위치
-      rect1Bottom < elementY || // 사각형 1의 아래쪽이 사각형 2의 위쪽보다 위에 위치
-      charX > rect2Right || // 사각형 1의 왼쪽이 사각형 2의 오른쪽보다 오른쪽에 위치
+      rect1Right < elementX ||
+      rect1Bottom < elementY ||
+      charX > rect2Right ||
       charY > rect2Bottom
-    ); // 사각형 1의 위쪽이 사각형 2의 아래쪽보다 아래에 위치
+    );
   };
 
   useEffect(() => {
@@ -235,165 +250,97 @@ const Map = () => {
     const cy = characterY - backgroundY;
 
     setIsNearPhoto(isNear(cx, cy, photoX, photoY, photoWidth, photoHeight));
-    setIsNearPhotomap(
-      isNear(cx, cy, photomapX, photomapY, photomapWidth, photomapHeight)
-    );
-    setIsNearGuestbook(
-      isNear(cx, cy, guestbookX, guestbookY, guestbookWidth, guestbookHeight)
-    );
+    setIsNearPhotomap(isNear(cx, cy, photomapX, photomapY, photomapWidth, photomapHeight));
+    setIsNearGuestbook(isNear(cx, cy, guestbookX, guestbookY, guestbookWidth, guestbookHeight));
     setIsNearRadio(isNear(cx, cy, radioX, radioY, radioWidth, radioHeight));
   }, [characterX, characterY, backgroundX, backgroundY]);
 
   const handleArrowKeyDown = (e) => {
-    if (e.key === 'Enter' && !isChatting) {
-      setIsChatting(true);
-    }
-    if ((e.key === 'Escape') & isChatting) {
-      setIsChatting(false);
-    }
+    if (e.key === 'Enter' && !isChatting) setIsChatting(true);
+    if (e.key === 'Escape' && isChatting) setIsChatting(false);
   };
   useEffect(() => {
     document.addEventListener('keydown', handleArrowKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleArrowKeyDown);
-    };
-  }, [handleArrowKeyDown]);
+    return () => document.removeEventListener('keydown', handleArrowKeyDown);
+  }, [isChatting]);
+
+  // messageObj는 ChatBox에서 setMessageObj로 갱신됨
 
   return (
     <>
       {loading ? (
         <LoadingBus />
       ) : (
-        <div className='w-full h-full overflow-hidden'>
+        <div className="w-full h-full overflow-hidden">
           <Stage width={width} height={height}>
-            {/* 배경을 관리하는 Container */}
+            {/* 배경 */}
             <Container>
               <Sprite image={mapImages.map} x={backgroundX} y={backgroundY} />
             </Container>
-            {/* 정적인 요소를 관리하는 Container */}
+
+            {/* 정적 요소 */}
             <Container>
-              <Sprite
-                image={mapImages.photo}
-                width={photoWidth}
-                height={photoHeight}
-                x={calculateStaticElementPosition().px}
-                y={calculateStaticElementPosition().py}
+              <Sprite image={mapImages.photo} width={photoWidth} height={photoHeight}
+                x={calculateStaticElementPosition().px} y={calculateStaticElementPosition().py}
                 filters={isNearPhoto ? [outlineStyle] : []}
               />
-              <Sprite
-                image={mapImages.photomap}
-                width={photomapWidth}
-                height={photomapHeight}
-                x={calculateStaticElementPosition().pmx}
-                y={calculateStaticElementPosition().pmy}
+              <Sprite image={mapImages.photomap} width={photomapWidth} height={photomapHeight}
+                x={calculateStaticElementPosition().pmx} y={calculateStaticElementPosition().pmy}
                 filters={isNearPhotomap ? [outlineStyle] : []}
               />
-              <Sprite
-                image={mapImages.guestbook}
-                width={guestbookWidth}
-                height={guestbookHeight}
-                x={calculateStaticElementPosition().gx}
-                y={calculateStaticElementPosition().gy}
+              <Sprite image={mapImages.guestbook} width={guestbookWidth} height={guestbookHeight}
+                x={calculateStaticElementPosition().gx} y={calculateStaticElementPosition().gy}
                 filters={isNearGuestbook ? [outlineStyle] : []}
               />
-              <Sprite
-                image={mapImages.radio}
-                width={radioWidth}
-                height={radioHeight}
-                x={calculateStaticElementPosition().rx}
-                y={calculateStaticElementPosition().ry}
+              <Sprite image={mapImages.radio} width={radioWidth} height={radioHeight}
+                x={calculateStaticElementPosition().rx} y={calculateStaticElementPosition().ry}
                 filters={isNearRadio ? [outlineStyle] : []}
               />
               {isNearRadio && (
-                <Sprite
-                  image={mapImages.keyRadio}
-                  width={120}
-                  height={60}
+                <Sprite image={mapImages.keyRadio} width={120} height={60}
                   x={calculateStaticElementPosition().rx - 20}
                   y={calculateStaticElementPosition().ry - radioHeight}
                 />
               )}
-              <AnimatedSprite
-                textures={fountain}
-                isPlaying={true}
-                animationSpeed={0.1}
-                x={fountainX + backgroundX}
-                y={fountainY + backgroundY}
-                width={fountainWidth}
-                height={fountainHeight}
+              <AnimatedSprite textures={fountain} isPlaying animationSpeed={0.1}
+                x={fountainX + backgroundX} y={fountainY + backgroundY}
+                width={fountainWidth} height={fountainHeight}
               />
-              <AnimatedSprite
-                textures={seagullPeck}
-                isPlaying={true}
-                animationSpeed={0.08}
-                x={280 + backgroundX}
-                y={525 + backgroundY}
-                width={27}
-                height={24}
+              <AnimatedSprite textures={seagullPeck} isPlaying animationSpeed={0.08}
+                x={280 + backgroundX} y={525 + backgroundY} width={27} height={24}
               />
-              <AnimatedSprite
-                textures={seagullTakeoff}
-                isPlaying={true}
-                animationSpeed={0.1}
-                x={255 + backgroundX}
-                y={525 + backgroundY}
-                width={27}
-                height={24}
+              <AnimatedSprite textures={seagullTakeoff} isPlaying animationSpeed={0.1}
+                x={255 + backgroundX} y={525 + backgroundY} width={27} height={24}
               />
-              <AnimatedSprite
-                textures={sql}
-                isPlaying={true}
-                animationSpeed={0.1}
-                x={400 + backgroundX}
-                y={600 + backgroundY}
-                width={32}
-                height={32}
+              <AnimatedSprite textures={sql} isPlaying animationSpeed={0.1}
+                x={400 + backgroundX} y={600 + backgroundY} width={32} height={32}
               />
-              <AnimatedSprite
-                textures={sqr}
-                isPlaying={true}
-                animationSpeed={0.1}
-                x={360 + backgroundX}
-                y={593 + backgroundY}
-                width={40}
-                height={40}
+              <AnimatedSprite textures={sqr} isPlaying animationSpeed={0.1}
+                x={360 + backgroundX} y={593 + backgroundY} width={40} height={40}
               />
-              {fishs.map((fish, index) => (
-                <FishShadow
-                  key={index}
-                  x={fish.x + backgroundX}
-                  y={fish.y + backgroundY}
-                  delay={getRandomDelay()}
-                />
+              {fishs.map((fish, i) => (
+                <FishShadow key={i} x={fish.x + backgroundX} y={fish.y + backgroundY} delay={getRandomDelay()} />
               ))}
-              {waterLeafs.map((leaf, index) => (
-                <WaterLeaf
-                  key={index}
-                  x={leaf.x + backgroundX}
-                  y={leaf.y + backgroundY}
-                  delay={getRandomDelay()}
-                />
+              {waterLeafs.map((leaf, i) => (
+                <WaterLeaf key={i} x={leaf.x + backgroundX} y={leaf.y + backgroundY} delay={getRandomDelay()} />
               ))}
-              <RandomWaterDrops
-                backgroundX={backgroundX}
-                backgroundY={backgroundY}
-              />
+              <RandomWaterDrops backgroundX={backgroundX} backgroundY={backgroundY} />
             </Container>
-            {/* 캐릭터를 관리하는 Container */}
+
+            {/* 캐릭터 */}
             <Container>
               <CharacterInMap
                 width={width}
                 height={height}
                 nickname={nickname}
                 costume={costume}
-                stompClient={client}
-                connected={connected}
-                token={groupInfo.woomsInviteCode}
-                setBackgroundX={setBackgroundX}
-                setBackgroundY={setBackgroundY}
-                messageObj={messageObj}
+                // 렌더/입력
                 backgroundX={backgroundX}
                 backgroundY={backgroundY}
+                setBackgroundX={setBackgroundX}
+                setBackgroundY={setBackgroundY}
+                setCharacterX={setCharacterX}
+                setCharacterY={setCharacterY}
                 isOpenPhoto={isOpenPhoto}
                 isOpenPhotomap={isOpenPhotomap}
                 isOpenGuestbook={isOpenGuestbook}
@@ -402,36 +349,30 @@ const Map = () => {
                 setIsInteractive={setIsInteractive}
                 setRadioReadInteractive={setRadioReadInteractive}
                 setRadioWriteInteractive={setRadioWriteInteractive}
-                setCharacterX={setCharacterX} // 캐릭터의 X 위치를 상위 컴포넌트로 전달
-                setCharacterY={setCharacterY} // 캐릭터의 Y 위치를 상위 컴포넌트로 전달
                 isChatting={isChatting}
+                // WS
+                connected={connected}
+                sendMove={sendMove}
+                others={others}
+                // 채팅 말풍선용
+                messageObj={messageObj}
               />
             </Container>
           </Stage>
-          {isOpenPhoto && (
-            <PhotoModal onClose={handleClosePhoto} woomsId={woomsId} />
-          )}
-          {isOpenPhotomap && (
-            <PhotoHeatMap onClose={handleClosePhotomap} woomsId={woomsId} />
-          )}
-          {isOpenGuestbook && (
-            <CommentModal onClose={handleCloseGuestbook} woomsId={woomsId} />
-          )}
-          {isOpenRadioRead && (
-            <StoryReadModal onClose={handleCloseRadioRead} woomsId={woomsId} />
-          )}
-          {isOpenRadioWrite && (
-            <StoryWriteModal
-              onClose={handleCloseRadioWrite}
-              woomsId={woomsId}
-            />
-          )}
 
+          {/* 모달들 */}
+          {isOpenPhoto && <PhotoModal onClose={handleClosePhoto} woomsId={roomId} />}
+          {isOpenPhotomap && <PhotoHeatMap onClose={handleClosePhotomap} woomsId={roomId} />}
+          {isOpenGuestbook && <CommentModal onClose={handleCloseGuestbook} woomsId={roomId} />}
+          {isOpenRadioRead && <StoryReadModal onClose={handleCloseRadioRead} woomsId={roomId} />}
+          {isOpenRadioWrite && <StoryWriteModal onClose={handleCloseRadioWrite} woomsId={roomId} />}
+
+          {/* 채팅 박스 (기존 그대로) */}
           <ChatBox
             stompClient={client}
             connected={connected}
             nickname={nickname}
-            token={groupInfo.woomsInviteCode}
+            token={roomId}               // 방 식별자 통일
             setIsChatting={setIsChatting}
             isChatting={isChatting}
             setMessageObj={setMessageObj}


### PR DESCRIPTION
## 🙆‍♂️ Issue
#249 

## 📝 Description
1. 방에 입장했을 때, 누군가가 움직이기 전까지 기존 인원이 보이지 않음
2. 사용자가 이탈해도 타 사용자 화면에서 유령 캐릭터(잔상) 가 남음
3. 움직임 없이 장시간 대기시 세션 종료 수정

## ✨ Feature

1. **타인 목록 단일 소스화**
   * 타인 목록(`others`)을 `Map` 컴포넌트에서만 보유/업데이트하도록 상태 승격(State hoisting)
   * `CharacterInMap`은 렌더 전용으로 단순화(로컬 `characters` 상태 제거)

2. **세션 식별자 기반 업서트/제거**
   * `/user/queue/init`(스냅샷), `/ws/wooms/move/{roomId}`(업서트), `/ws/wooms/disconnect/{roomId}`(제거) 모두 **`sessionId` 기준** 처리

3. **입장 직후 1회 move 발행**
   * `connected === true` 순간 현재 좌표로 **초기 1회 `sendMove()`** 전송(재연결 시 1회 재발행)
   * 중복 전송 방지를 위한 `announcedRef` 도입 및 `onDisconnect` 시 ref 리셋

4. **유령 제거 강화**
   * `disconnect` 수신 시 **`sessionId` 기준**으로 목록에서 즉시 제거
   * 부모(`Map`)만 상태를 소유하므로 하위 컴포넌트의 로컬 상태로 되살아나는 현상 제거

5. **채팅 말풍선 처리 정리**
   * 내 말풍선은 `CharacterInMap`에서만 관리
   * 타인 메시지는 부모에서 받은 `messageObj`를 **렌더 시 합성**하여 표시(상태 중복 관리 제거)

6. **구독/정리(Subscription lifecycle) 정비**
   * `init/move/disconnect` **모든 구독과 해제**를 `Map`에서 일원화
   * 언마운트 시 `unsubscribe()` 철저히 수행하여 메모리 누수/중복 수신 방지

7. **장시간 대기(세션 종료) 대응**
   * STOMP 연결 끊김 감지 시 `announcedRef` 리셋 → 재연결 후 **초기 1회 move 재발행**
   * 하트비트 사용으로 세션 연결 유지


## 👌 Review
This closes #249 
